### PR TITLE
Use fixed version tags for images

### DIFF
--- a/influx/docker-compose.yml
+++ b/influx/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   influxdb:
-    image: influxdb:alpine
+    image: influxdb:1.4.3-alpine
     deploy:
       replicas: 1
       labels:
@@ -16,7 +16,7 @@ services:
       - traefik-net
 
   chronograf:
-    image: chronograf:alpine
+    image: chronograf:1.4.0.1-alpine
     deploy:
       replicas: 1
       labels:
@@ -34,7 +34,7 @@ services:
       - traefik-net
 
   kapacitor:
-    image: kapacitor:alpine
+    image: kapacitor:1.4.0-alpine
     deploy:
       replicas: 1
     volumes:

--- a/mosquitto/docker-compose.yml
+++ b/mosquitto/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   mosquitto:
-    image: eclipse-mosquitto:latest
+    image: eclipse-mosquitto:1.4.12
     deploy:
       replicas: 1
       labels:

--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   portainer:
-    image: portainer/portainer
+    image: portainer/portainer:1.16.1
     command: "-H unix:///var/run/docker.sock"
     deploy:
       replicas: 1

--- a/telegraf/docker-compose.yml
+++ b/telegraf/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 services:
 
   telegraf-global:
-    image: telegraf:alpine
+    image: telegraf:1.5.2-alpine
     deploy:
       mode: global
     configs:
@@ -15,7 +15,7 @@ services:
       - traefik-net
 
   telegraf-manager:
-    image: telegraf:alpine
+    image: telegraf:1.5.2-alpine
     deploy:
       replicas: 1
       placement:

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   traefik:
-    image: traefik:alpine
+    image: traefik:1.5.1-alpine
     deploy:
       replicas: 1
       placement:


### PR DESCRIPTION
Use fixed version on images.  Ensures fully repeatable deployment, and
defined upgrades.  Also means we can upgrade images with docker stack
deploy.